### PR TITLE
Add  manager_mail_committer.

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -56,6 +56,7 @@ you can use :func:`reportmail.reporter.console_committer()` like this:
 django-reportmail provides two committer functions from it's own:
 
 * :func:`reportmail.reporter.admin_mail_committer`: sending as admin mail (default committer)
+* :func:`reportmail.reporter.manager_mail_committer`: sending as manager mail
 * :func:`reportmail.reporter.console_committer`: printing out to the standard output
 
 Or, you can simply set a 'Committer' function to the

--- a/reportmail/reporter.py
+++ b/reportmail/reporter.py
@@ -12,12 +12,13 @@ In this module, these two characters are meaningful.
 
     * reportmail.reporter.console_committer
     * reportmail.reporter.admin_mail_committer
+    * reportmail.reporter.manager_mail_committer
 
 Internally Reporter uses Committer to tell messages.
 So committers are totally separated from reporters and reporter delegates the sending processing to
 committers.
 """
-from django.core.mail import mail_admins
+from django.core.mail import mail_admins, mail_managers
 from django.template import Context
 from django.template.loader import get_template
 
@@ -134,3 +135,17 @@ def admin_mail_committer(subject, body):
     and use body as mail body.
     """
     mail_admins(subject, body, fail_silently=True)
+
+
+def manager_mail_committer(subject, body):
+    """ One of committers to send messages to Manager Mails.
+
+    This committer depends on django's django.core.mail.mail_managers.
+    So you need to set 'MANAGERS' of the settings file.
+    Notice that thin committer will fail silently to avoid
+    causing unexpected error while sending manager mails.
+
+    This committer will simply use the subject as mail subject,
+    and use body as mail body.
+    """
+    mail_managers(subject, body, fail_silently=True)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -75,3 +75,22 @@ class TestAdminMailCommitter(TestCase):
         self.assertEqual(mail.outbox[0].to, ['admin@example.com'])
         self.assertEqual(mail.outbox[0].subject, "Admin mail")
         self.assertEqual(mail.outbox[0].body, "This is test")
+
+
+class TestMangerMailCommitter(TestCase):
+    def _callFUT(self, *args, **kwargs):
+        from reportmail.reporter import manager_mail_committer
+        return manager_mail_committer(*args, **kwargs)
+
+    @override_settings(SERVER_EMAIL='server@example.com',
+                       MANAGERS=(('Manager', 'manager@example.com'),),
+                       EMAIL_SUBJECT_PREFIX="")
+    def test__commit(self):
+        self._callFUT("Manager mail", "This is test")
+
+        from django.core import mail
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, 'server@example.com')
+        self.assertEqual(mail.outbox[0].to, ['manager@example.com'])
+        self.assertEqual(mail.outbox[0].subject, "Manager mail")
+        self.assertEqual(mail.outbox[0].body, "This is test")


### PR DESCRIPTION
Hi @hirokiky.

First, thanks for the good library

I added "reportmail.reporter.manager_mail_committer". Because I think some people who want to use different ADMINS and MANAGERS.

see also https://docs.djangoproject.com/en/1.7/topics/email/#mail-managers. 

Please dismiss If it were not necessary.
